### PR TITLE
Fix to message borders and added highlight to selected message

### DIFF
--- a/styles/overriden_internal_packages/thread-list.less
+++ b/styles/overriden_internal_packages/thread-list.less
@@ -5,17 +5,11 @@
 	.list-item {
 		background-color: @background-primary;
 	}
-	.list-column {
-   		border-bottom: 1px solid @background-secondary;
-  	}
 
 	.unread:not(.focused):not(.selected) {
 		&:hover {
 			background: @background-secondary;
 		}
-		.list-column {
-    		border-bottom: 1px solid @background-secondary;
-  		}
 	}
 
 	.thread-icon {
@@ -30,7 +24,7 @@
 		&.thread-icon-replied {
       		background-image: url("nylas://N1-Predawn/styles/images/thread-list/icon-replied-@2x.png");
     	}
-    	
+
     	&.thread-icon-forwarded {
       		background-image:url("nylas://N1-Predawn/styles/images/thread-list/icon-forwarded-@2x.png");
     	}
@@ -44,4 +38,12 @@
 .thread-list .thread-icon-star:hover
 {
 	background-image: url("nylas://N1-Predawn/styles/images/thread-list/icon-star-@2x.png");
+}
+
+.list-tabular {
+	.list-tabular-item {
+		&.keyboard-cursor {
+			border-left-color: @accent-primary;
+		}
+	}
 }


### PR DESCRIPTION
On the last N1 update, thread borders were out of the line.

![screenshot 2016-02-28 02 04 43](https://cloud.githubusercontent.com/assets/3808430/13377576/c4139478-ddbf-11e5-9cb2-cf1aebfa038a.png)

Highlight with orange color was added to border-left of thread message when it's selected.

![screenshot 2016-02-28 02 05 24](https://cloud.githubusercontent.com/assets/3808430/13377577/c416334a-ddbf-11e5-9afe-5b72e53111ee.png)
