### PR TITLE
Add theme colors and update display name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "N1-Predawn",
+  "displayName": "Predawn",
   "theme": "ui",
   "version": "0.1.0",
   "description": "The Predawn N1 Client Theme",

--- a/styles/theme-colors.less
+++ b/styles/theme-colors.less
@@ -1,0 +1,1 @@
+@toolbar-background-color: #282828;


### PR DESCRIPTION
Hey, @adambmedia! I'm part of the Nylas team, and we're about to land a new visual theme picker that'll allow people to preview and view color palettes for themes. We pull a few major colors from the theme's UI variables to create the palette, but we've also added a way to override them manually with a `theme-colors.less` file for themes (like yours) with colors that aren't conveyed as well.

Here's what it looks like:
<img width="113" alt="screen shot 2016-03-03 at 1 09 23 pm" src="https://cloud.githubusercontent.com/assets/8452682/13509682/89447eae-e141-11e5-80c6-14d332e247fd.png">
